### PR TITLE
Correct webhook url

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,8 +19,7 @@ const client = new line.Client(config);
 const app = express();
 
 // register a webhook handler with middleware
-// about the middleware, please refer to doc
-app.post('/', line.middleware(config), (req, res) => {
+app.post('/webhook', line.middleware(config), (req, res) => {
     Promise
         .all(req.body.events.map(handleEvent))
         .then((result) => res.json(result))


### PR DESCRIPTION
Fixes #34 

Changes: Simply changed webhook url from `/` to `/webhook`.
