### PR TITLE
Get picture responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,10 +119,19 @@ function handleEvent(event) {
             var type = (JSON.parse(body1)).answers[0].actions;
             var ans = (JSON.parse(body1)).answers[0].actions[0].expression;
             if (type.length == 1 && type[0].type == "answer") {
-                const answer = {
-                    type: 'text',
-                    text: ans
-                };
+                let answer;
+                if((JSON.parse(body1)).answers[0].data[0].type === 'photo'){
+                    answer = {
+                        type: 'image',
+                        originalContentUrl: ans,
+                        previewImageUrl: ans
+                    };
+                } else {
+                    answer = {
+                        type: 'text',
+                        text: ans
+                    };
+                }
                 // use reply API
                 return client.replyMessage(event.replyToken, answer);
             } else if (type.length == 3 && type[2].type == "map") {


### PR DESCRIPTION
Fixes #36 

Changes: Now whenever the response from SUSI server is a link to a picture, the image is sent as response to the user rather than its url.

Screenshots for the change: 

Before-
<img width="250" alt="screen shot 2018-05-19 at 3 53 52 pm" src="https://user-images.githubusercontent.com/31174685/40276524-226727d4-5c2a-11e8-9b46-aac24db0db9b.jpg">

After-
<img width="250" alt="screen shot 2018-05-19 at 3 53 52 pm" src="https://user-images.githubusercontent.com/31174685/40276829-89660af2-5c31-11e8-97b0-04eefaf07de9.jpg">
